### PR TITLE
Feature/v5 support

### DIFF
--- a/src/RedactorFa.php
+++ b/src/RedactorFa.php
@@ -2,6 +2,7 @@
 
 namespace Ryssbowh\RedactorFa;
 
+use craft\i18n\PhpMessageSource;
 use Ryssbowh\RedactorFa\assets\bundles\SettingsBundle;
 use Ryssbowh\RedactorFa\models\Settings;
 use Ryssbowh\RedactorFa\services\FaService;
@@ -92,5 +93,18 @@ class RedactorFa extends Plugin
                 'faVersionOptions' => $this->fa->versions
             ]
         );
+    }
+
+    /**
+     * Register Translation
+     */
+    private function registerTranslation(): void
+    {
+        \Craft::$app->i18n->translations['redactor-fa'] = [
+            'class' => PhpMessageSource::class,
+            'sourceLanguage' => 'en',
+            'basePath' => __DIR__ . '/translations',
+            'allowOverrides' => true,
+        ];
     }
 }

--- a/src/assets/js/redactor-plugins/fontawesome/fontawesome.js
+++ b/src/assets/js/redactor-plugins/fontawesome/fontawesome.js
@@ -71,6 +71,16 @@ class FaGraphQl {
 }
 
 !(function (i) {
+    const styleToPrefixV5 = {
+        'solid'     : 'fas',
+        'regular'   : 'far',
+        'light'     : 'fal',
+        'thin'      : 'fat',
+        'duotone'   : 'fad',
+        'brands'    : 'fab',
+        'kit'       : 'fak'
+    };
+
     i.add("plugin", "fontawesome", {
         keyupTimeout: null,
         modal: null,
@@ -153,7 +163,7 @@ class FaGraphQl {
         },
         start: function () {
             var i = { title: this.lang.get("title"), api: "plugin.fontawesome.open" };
-            this.toolbar.addButton("title", i).setIcon('<i class="fa-solid fa-font-awesome"></i>');
+            this.toolbar.addButton("title", i).setIcon(`<i class="${ parseInt(this.opts.redactorFaApi.version) == 5 ? 'fab':'fa-solid'} fa-font-awesome"></i>`);
         },
         open: function () {
             var options = {
@@ -188,6 +198,9 @@ class FaGraphQl {
             icons.forEach((icon) => {
                 icon.styles.forEach((style) => {
                     let faClass = 'fa-' + style + ' fa-' + icon.id;
+                    if (parseInt(this.opts.redactorFaApi.version) == 5) {
+                        faClass = styleToPrefixV5[style] + ' fa-' + icon.id;
+                    }
                     let elem = document.createElement('div');
                     elem.classList.add('icon');
                     elem.innerHTML = '<i class="' + faClass + '"></i><label><span>' + icon.label + '</span><code>' + faClass + '</code></label>';
@@ -213,7 +226,14 @@ class FaGraphQl {
         {
             this._closeList();
             this.app.api('module.modal.close');
-            this.insertion.insertHtml('<span><i class="' + faClass + '"></i></span>');
+            let classes = faClass.split(' ');
+            let span = $R.dom('<span>');
+            let icon = document.createElement('i');
+            classes.forEach((ele) => {
+                icon.classList.add(ele);
+            })
+            span.add(icon);
+            this.insertion.insertNode(span, 'after');;
         }
     });
 })(Redactor);

--- a/src/translations/en/redactor-fa.php
+++ b/src/translations/en/redactor-fa.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    "This folder doesn't exist" => "This folder doesn't exist",
+];


### PR DESCRIPTION
* Add support for font awesome 5, there is a different css style used in v5 and v6. Please refer [here](https://fontawesome.com/v5/docs/web/reference-icons/) for version 5.
* Use insertNode instead of insertHTML when adding the icon html. Issue #2. 
* Fix the translation issue by registering the translation for plugin. I look in your service code there are some translation with category redactor-fa.

Btw I am not yet updated `js` inside the `dist` folder. 
Feel free to reject or update this PR. 